### PR TITLE
jenkinsx-quickstart-nuxeo-poc to 1.0.3

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -1,9 +1,12 @@
 dependencies:
-- name: exposecontroller
-  version: 2.3.82
+- alias: expose
+  name: exposecontroller
   repository: http://chartmuseum.jenkins-x.io
-  alias: expose
-- name: exposecontroller
   version: 2.3.82
+- alias: cleanup
+  name: exposecontroller
   repository: http://chartmuseum.jenkins-x.io
-  alias: cleanup
+  version: 2.3.82
+- name: jenkinsx-quickstart-nuxeo-poc
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 1.0.3


### PR DESCRIPTION
Promote jenkinsx-quickstart-nuxeo-poc to version 1.0.3