### PR TITLE
jenkinsx-quickstart-nuxeo-poc to 1.0.17

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -9,4 +9,4 @@ dependencies:
   version: 2.3.82
 - name: jenkinsx-quickstart-nuxeo-poc
   repository: http://jenkins-x-chartmuseum:8080
-  version: 1.0.16
+  version: 1.0.17


### PR DESCRIPTION
Promote jenkinsx-quickstart-nuxeo-poc to version 1.0.17